### PR TITLE
[js] Init update backup with correct type

### DIFF
--- a/static/ui/js/index.js
+++ b/static/ui/js/index.js
@@ -70,19 +70,19 @@ var App = (function () {
     function requestUpdateBackupFromForm() {
         let backupId = $("#update-backup-form-backup-id").val();
         let requestBackup = {backup_id: backupId};
-        requestBackup.table = "";
+        requestBackup.table = [];
         let tables = $("#update-backup-form-bigquery-table").val();
         if (0 < tables.length) {
             requestBackup.table = tables.split(",")
         }
 
-        requestBackup.excluded_tables = "";
+        requestBackup.excluded_tables = [];
         let excluded_tables = $("#update-backup-form-bigquery-excluded_tables").val();
         if (0 < excluded_tables.length) {
             requestBackup.excluded_tables = excluded_tables.split(",")
         }
-        requestBackup.include_path = "";
-        requestBackup.exclude_path = "";
+        requestBackup.include_path = [];
+        requestBackup.exclude_path = [];
         let storageInclude = $("#update-backup-form-storage-include").val();
         if (0 < storageInclude.length) {
             requestBackup.include_path = storageInclude.split(",");


### PR DESCRIPTION
Fix unmarshall error: `json: cannot unmarshal string into Go struct field UpdateRequest.table of type []string`

POC:

```
package main

import (
	"encoding/json"
	"fmt"
	"github.com/ottogroup/penelope/pkg/requestobjects"
)

func main() {
	ur := requestobjects.UpdateRequest{}
	data := `{"backup_id":"xxx-zzz-qqq-2e-casdfsdef","table":"","excluded_tables":"","include_path":"","exclude_path":["temp","temp2"],"archive_ttm":0}`
	err := json.Unmarshal([]byte(data), &ur)
	if err != nil {
		panic(err)
	}
	println(fmt.Sprintf("%+v", ur))
}
```
